### PR TITLE
RPT-4828 createSession の scope 指定サンプルを追加

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
       stringio
     puma (6.4.3)
       nio4r (~> 2.0)
-    raas-client-rails (0.1.13)
+    raas-client-rails (0.1.14)
       rails (>= 6.1.7)
     racc (1.8.1)
     rack (3.1.7)

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ class RaasController < ApplicationController
       @sub = "sample_user_id"
       # 現在のセッションのサブドメインをセットする(セッションごとにサブドメインが異なる場合)
       # @sub_domain = "sample_sub_domain"
+      # 現在のユーザーに許可するスコープをセットする(スコープによる権限管理を使う場合、空白区切り)
+      # @scope = "csv_admin.invoice pdf.invoice"
   end
 end
 ```

--- a/app/controllers/raas_controller.rb
+++ b/app/controllers/raas_controller.rb
@@ -5,13 +5,15 @@ class RaasController < ApplicationController
 
   # 必須：テナントID、ユーザーIDをRaasに渡す
   def prepare_tenant_and_sub
-      super
-      # 現在のセッションのテナントIDをセットする
-      @tenant = "sample_tenant_id"
-      # 現在のセッションのユーザーIDをセットする
-      @sub = "sample_user_id"
+    super
+    # 現在のセッションのテナントIDをセットする
+    @tenant = "sample_tenant_id"
+    # 現在のセッションのユーザーIDをセットする
+    @sub = "sample_user_id"
     # 現在のセッションのサブドメインをセットする(セッションごとにサブドメインが異なる場合)
     # @sub_domain = "sample_sub_domain"
+    # 現在のユーザーに許可するスコープをセットする(スコープによる権限管理を使う場合、空白区切り)
+    # @scope = "csv_admin.invoice pdf.invoice"
   end
 
   # サンプル：レイアウト一覧の取得


### PR DESCRIPTION
## 概要

RPT-3714（scope 別 Route 制限）対応の raas-client-rails 0.1.14 に更新し、scope 指定のサンプルコードを追加。

## 変更内容

- `raas-client-rails` を 0.1.13 → 0.1.14 に更新（session 作成時の scope 送信をサポート）
- `raas_controller.rb` / README の `prepare_tenant_and_sub` に `@scope` のコメント付きサンプルを追記
- ついでに `prepare_tenant_and_sub` のインデントを rubocop 準拠（2スペース）に正規化

## 動作確認

- 本サンプルアプリ（fsghis dev 設定）から `@scope = "pdf.invoice"` を有効化して session を作成し、authorizer の `[scope-check] deny` が発動することを確認済み（CloudWatch `reportAggregateLambda`、2026-07-24 13:04 JST）

関連: https://sutech.atlassian.net/browse/RPT-4828
関連PR: https://github.com/SuTech-JP/raas-client-for-rails/pull/6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aj3Jq4W3QiwPFYve6z2qcZ