### PR TITLE
RPT-4828 Bump raas-client-rails to 0.1.16

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
       stringio
     puma (6.4.3)
       nio4r (~> 2.0)
-    raas-client-rails (0.1.14)
+    raas-client-rails (0.1.15)
       rails (>= 6.1.7)
     racc (1.8.1)
     rack (3.1.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
       stringio
     puma (6.4.3)
       nio4r (~> 2.0)
-    raas-client-rails (0.1.15)
+    raas-client-rails (0.1.16)
       rails (>= 6.1.7)
     racc (1.8.1)
     rack (3.1.7)


### PR DESCRIPTION
## 概要

`raas-client-rails` を rubygems 公開版 **0.1.16** へ更新する（Gemfile.lock のみ、2 コミットで 0.1.14 → 0.1.15 → 0.1.16）。

## 取り込まれる変更（gem 側 [SuTech-JP/raas-client-for-rails#7](https://github.com/SuTech-JP/raas-client-for-rails/pull/7)）

### 0.1.15
- **SCC トークン発行（`/external/token`）への scope 送信** — scope 指定時、SCC 認証経路でも scope 別 Route 制限（RPT-3714）が発火するようになる。scope 未指定時の挙動は不変
- scope 別トークンキャッシュ + エラー応答の非キャッシュ
- 汎用プロキシの修正（parameters 省略 GET の 500 解消・上流ステータス透過・POST/PUT/DELETE の応答返却）

### 0.1.16
- `mimeType=file` ダウンロードがファイル本体でなく `Net::HTTPResponse` の inspect 文字列になるバグを修正

## 動作確認

- 本サンプルアプリ + dev 環境（fsghis テナント）で 0.1.16 実機確認済み: scope 付きトークンで不許可 route が 403、scope なしで従来どおり 200
- Rails 本体ほか他依存は据え置き（`bundle update raas-client-rails --conservative`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)